### PR TITLE
Introduce key path to shared state extension

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/SceneBox.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/SceneBox.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SceneBox"
+               BuildableName = "SceneBox"
+               BlueprintName = "SceneBox"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SceneBoxTests"
+               BuildableName = "SceneBoxTests"
+               BlueprintName = "SceneBoxTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SceneBoxTests"
+               BuildableName = "SceneBoxTests"
+               BlueprintName = "SceneBoxTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "SceneBox"
+            BuildableName = "SceneBox"
+            BlueprintName = "SceneBox"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Based on these two pain points, I conceived the framework to enable us to develo
 
 To integrate using Apple's SPM, add following as a dependency to your Target.
 
-`.package(url: "https://github.com/lumiasaki/SceneBox.git", .upToNextMajor(from: "0.2.4"))`
+`.package(url: "https://github.com/lumiasaki/SceneBox.git", .upToNextMajor(from: "0.3.0"))`
 
 ## How to use
 
@@ -107,11 +107,11 @@ class MyViewController: UIViewController, Scene {
     var sceneIdentifier: UUID!
   
     func saveValue() {
-        sbx.putSharedState(by: "Color", sharedState: UIColor.red)
+        sbx.putSharedState(by: \.color, sharedState: UIColor.red)
     }
     
     func fetchValue() {
-        let color: UIColor? = sbx.getSharedState(by: "Color")
+        let color: UIColor? = sbx.getSharedState(by: \.color)
     }
     
     func pushToNext() {
@@ -131,7 +131,7 @@ class MyViewController: UIViewController, Scene {
 
     var sceneIdentifier: UUID!
   
-    @SceneBoxSharedStateInjected(key: "Color")
+    @SharedStateInjected(\.timestamp)
     private var color: UIColor?
     
     init() {
@@ -157,7 +157,9 @@ In general, after initializing a `SceneBox`, it can be held manually by the call
 
 ### Scene
 
-The `Scene` represents a page in the `SceneBox`, which is currently limited in the `UIViewController` class, and the limitation may be removed in the future. The fact that `Scene` is a protocol means that using `SceneBox` does not need to change the inheritance of your existing code, making it relatively easy to transform an existing `UIViewController` into a class that can be used in `SceneBox`. `Scene` provides a number of capabilities that can be used in `SceneBox`, such as `getSharedState(by:)`, `putSharedState(state:key:)` and so on.
+The `Scene` represents a page in the `SceneBox`, which is currently limited in the `UIViewController` class, and the limitation may be removed in the future. The fact that `Scene` is a protocol means that using `SceneBox` does not need to change the inheritance of your existing code, making it relatively easy to transform an existing `UIViewController` into a class that can be used in `SceneBox`. `Scene` provides a number of capabilities that can be used in `SceneBox`, such as `getSharedState(by:)`, `putSharedState(state:keyPath:)` and so on.
+
+> For more details about shared state extension with key path, check this: https://github.com/lumiasaki/SceneBox/issues/10
 
 Once a `UIViewController` is marked as conforming to the `Scene` protocol, you can access a number of capabilities under `sbx` namespace of your view controller. Even more, you can extend your own capabilities to the `Scene` under the namespace easily by extend `SceneCapabilityWrapper`, you can follow the guide to extend it.
 

--- a/Sources/SceneBox/Extension/Core/SharedStateExtension.swift
+++ b/Sources/SceneBox/Extension/Core/SharedStateExtension.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, message: "Use `SharedStateInjected<T>` instead.")
 @propertyWrapper
 public class SceneBoxSharedStateInjected<T> {
     
@@ -38,6 +39,80 @@ public class SceneBoxSharedStateInjected<T> {
             
             scene.sbx.putSharedState(by: key, sharedState: newValue)
         }
+    }
+}
+
+/// Property wrapper for helping developers to simplify state sharing among different `Scene`s, the principle of it is similar to `Environment` in SwiftUI, all `Scene`s share same source of truth through the `SharedStateExtension`, use this property wrapper will make developer to manipulate variables as normal properties, the only difference is that this one is backed by `SharedStateExtension` in static-type ( key path ) way.
+/// Notice: Because the property wrapper needs an instance of `Scene` to get capability from it, since that, you need to configure it before using it by calling `configure(scene:)` in a proper place.
+@propertyWrapper
+public struct SharedStateInjected<T> {
+    
+    private var scene: Scene?
+    
+    private let keyPath: WritableKeyPath<SharedStateValues, T?>
+    
+    public mutating func configure(scene: Scene?) {
+        self.scene = scene
+    }
+    
+    public var wrappedValue: T? {
+        get {
+            guard let scene = scene else {
+                fatalError("configure scene firstly")
+            }
+                        
+            return scene.sbx.getSharedState(by: keyPath)
+        }
+        
+        set {
+            guard let scene = scene else {
+                fatalError("configure scene firstly")
+            }
+            
+            scene.sbx.putSharedState(by: keyPath, sharedState: newValue)
+        }
+    }
+    
+    public init(_ keyPath: WritableKeyPath<SharedStateValues, T?>) {
+        self.keyPath = keyPath
+    }
+}
+
+/// This is an entry point for your custom keys.
+/// A case about how to create a custom key for your logic:
+/// ```swift
+/// struct TimestampKey: SharedStateKey {
+///
+///   // this will give compiler a hint about concrete type.
+///   static var currentValue: TimeInterval?
+/// }
+/// ```
+public protocol SharedStateKey {
+    
+    associatedtype ValueType
+    
+    static var currentValue: ValueType? { get set }
+}
+
+/// This is an entry point for extending your values.
+/// A case about how to create a key path for your value as below:
+/// ```swift
+/// extension SharedStateValues {
+///
+///   // this will generate a key path for `timestamp` variable.
+///   var timestamp: TimeInterval? {
+///     get { Self[TimestampKey.self] }
+///     set { Self[TimestampKey.self] = newValue }
+///   }
+/// }
+/// ```
+public struct SharedStateValues {
+    
+    public static var current = SharedStateValues()
+    
+    public static subscript<K: SharedStateKey>(key: K.Type) -> K.ValueType? {
+        get { key.currentValue }
+        set { key.currentValue = newValue }
     }
 }
 
@@ -77,8 +152,88 @@ public final class SharedStateExtension: Extension {
     // MARK: - Private
     
     private let workerQueue = DispatchQueue(label: "com.scenebox.shared-state.queue", attributes: .concurrent)
+    
+    @available(*, deprecated, message: "Use `stateValue` instead.")
     private var state: [AnyHashable : Any] = Dictionary()
     
+    private var stateValue: SharedStateValues = SharedStateValues()
+    
+    fileprivate func setSharedState<T>(_ sharedState: T?, on keyPath: WritableKeyPath<SharedStateValues, T?>) {
+        workerQueue.async(flags: .barrier) {
+            self.stateValue[keyPath: keyPath] = sharedState
+            
+            self.sceneBox?.dispatch(event: EventBus.EventName.sharedStateChanges, message: SharedStateMessage(key: keyPath, state: sharedState))
+            self.logger(content: "shared state changes: key: \(keyPath), state: \(String(describing: sharedState))")
+        }
+    }
+    
+    fileprivate func querySharedState<T>(by keyPath: WritableKeyPath<SharedStateValues, T?>) -> T? {
+        var result: T?
+        
+        workerQueue.sync {
+            result = stateValue[keyPath: keyPath]
+        }
+        
+        return result
+    }
+}
+
+extension SceneCapabilityWrapper {
+    
+    /// Receiving a shared state from the shared store if it exists.
+    /// - Parameter key: The key of the data you want to fetch from the store.
+    /// - Returns: The shared state stored in the extension. Nil if the data not exists with the provided key.
+    @available(*, deprecated, message: "Use `getSharedState<T>(by keyPath: WritableKeyPath<SharedStateValues, T?>) -> T?` instead.")
+    public func getSharedState(by key: AnyHashable) -> Any? {
+        guard let ext = try? _getExtension(by: SharedStateExtension.self) else {
+            return nil
+        }
+        
+        return ext.querySharedState(by: key)
+    }
+    
+    /// Receiving a shared state from the shared store if it exists.
+    /// - Parameter keyPath: Key path to the value by extending `SharedStateValues`.
+    /// - Returns: The shared state stored in the extension. Nil if the data not exists with the provided key path.
+    public func getSharedState<T>(by keyPath: WritableKeyPath<SharedStateValues, T?>) -> T? {
+        guard let ext = try? _getExtension(by: SharedStateExtension.self) else {
+            return nil
+        }
+        
+        return ext.querySharedState(by: keyPath)
+    }
+    
+    /// Putting a shared state to the shared store.
+    /// - Parameters:
+    ///   - key: The key of the data you want to put into the store.
+    ///   - sharedState: The shared state you want to save. Nil if you want to remove the data from the store.
+    @available(*, deprecated, message: "Use `putSharedState<T>(by keyPath: WritableKeyPath<SharedStateValues, T?>, sharedState: T?)` instead.")
+    public func putSharedState(by key: AnyHashable, sharedState: Any?) {
+        guard let ext = try? _getExtension(by: SharedStateExtension.self) else {
+            return
+        }
+        
+        ext.setSharedState(sharedState, on: key)
+    }
+    
+    /// Putting a shared state to the shared store.
+    /// - Parameters:
+    ///   - keyPath: Key path to the value by extending `SharedStateValues`.
+    ///   - sharedState: The shared state you want to save. Nil if you want to remove the data from the store.
+    public func putSharedState<T>(by keyPath: WritableKeyPath<SharedStateValues, T?>, sharedState: T?) {
+        guard let ext = try? _getExtension(by: SharedStateExtension.self) else {
+            return
+        }
+        
+        ext.setSharedState(sharedState, on: keyPath)
+    }
+}
+
+// MARK: - Deprecated
+
+extension SharedStateExtension {
+    
+    @available(*, deprecated, message: "Use `querySharedState<T>(by keyPath: WritableKeyPath<SharedStateValues, T?>) -> T?` instead.")
     fileprivate func querySharedState(by key: AnyHashable) -> Any? {
         var result: Any?
         
@@ -89,6 +244,7 @@ public final class SharedStateExtension: Extension {
         return result
     }
     
+    @available(*, deprecated, message: "Use `setSharedState<T>(_ sharedState: T?, on keyPath: WritableKeyPath<SharedStateValues, T?>)` instead.")
     fileprivate func setSharedState(_ sharedState: Any?, on key: AnyHashable) {
         workerQueue.async(flags: .barrier) {
             self.state[key] = sharedState
@@ -96,32 +252,5 @@ public final class SharedStateExtension: Extension {
             self.sceneBox?.dispatch(event: EventBus.EventName.sharedStateChanges, message: SharedStateMessage(key: key, state: sharedState))
             self.logger(content: "shared state changes: key: \(key), state: \(String(describing: sharedState))")
         }
-    }
-    
-}
-
-extension SceneCapabilityWrapper {
-    
-    /// Receiving a shared state from the shared store if it exists.
-    /// - Parameter key: The key of the data you want to fetch from the store.
-    /// - Returns: The shared state stored in the extension. Nil if the data not exists with the provided key.
-    public func getSharedState(by key: AnyHashable) -> Any? {
-        guard let ext = try? _getExtension(by: SharedStateExtension.self) else {
-            return nil
-        }
-        
-        return ext.querySharedState(by: key)
-    }
-    
-    /// Putting a shared state to the shared store.
-    /// - Parameters:
-    ///   - key: The key of the data you want to put into the store.
-    ///   - sharedState: The shared state you want to save. Nil if you want to remove the data from the store.
-    public func putSharedState(by key: AnyHashable, sharedState: Any?) {
-        guard let ext = try? _getExtension(by: SharedStateExtension.self) else {
-            return
-        }
-        
-        ext.setSharedState(sharedState, on: key)
     }
 }

--- a/Tests/SceneBoxTests/Support/Car.swift
+++ b/Tests/SceneBoxTests/Support/Car.swift
@@ -1,0 +1,18 @@
+//
+//  Car.swift
+//  SceneBox
+//
+//  Created by Lumia_Saki on 2021/7/27.
+//  Copyright © 2021年 tianren.zhu. All rights reserved.
+//
+
+import Foundation
+
+class Car {
+    
+    var name: String
+    
+    init(name: String) {
+        self.name = name
+    }
+}

--- a/Tests/SceneBoxTests/Support/SceneBoxTestSceneViewController.swift
+++ b/Tests/SceneBoxTests/Support/SceneBoxTestSceneViewController.swift
@@ -14,13 +14,18 @@ public final class SceneBoxTestSceneViewController: UIViewController, Scene {
     
     public var sceneIdentifier: UUID!
     
+    @SharedStateInjected(\.car)
+    var car: Car?
+    
     var isActiveScene: Bool { sbx.currentIsActiveScene() }
     var sceneDidLoadedBlock: (() -> Void)?
     var sceneWillUnloadedBlock: (() -> Void)?
-    var sceneBoxWillTerminateBlock: (() -> Void)?
+    var sceneBoxWillTerminateBlock: (() -> Void)?        
     
     public func sceneDidLoaded() {
         sceneDidLoadedBlock?()
+        
+        _car.configure(scene: self)
     }
     
     public func sceneWillUnload() {

--- a/Tests/SceneBoxTests/Support/SharedStateTestKey.swift
+++ b/Tests/SceneBoxTests/Support/SharedStateTestKey.swift
@@ -1,0 +1,36 @@
+//
+//  SharedStateTestKey.swift
+//  SceneBox
+//
+//  Created by Lumia_Saki on 2021/7/27.
+//  Copyright © 2021年 tianren.zhu. All rights reserved.
+//
+
+import Foundation
+import SceneBox
+
+struct TimestampKey: SharedStateKey {
+
+    static var currentValue: TimeInterval?
+}
+
+extension SharedStateValues {
+    
+    var timestamp: TimeInterval? {
+        get { Self[TimestampKey.self] }
+        set { Self[TimestampKey.self] = newValue }
+    }
+}
+
+struct CarKey: SharedStateKey {
+    
+    static var currentValue: Car?
+}
+
+extension SharedStateValues {
+    
+    var car: Car? {
+        get { Self[CarKey.self] }
+        set { Self[CarKey.self] = newValue }
+    }
+}


### PR DESCRIPTION
## Current situation

Shared state extension supports a simple dictionary driven store to save every single state and allows scenes to manipulate the state through the capabilities provided by shared state extension.

Developer needs to define a set of keys in any type which conform to `Hashable` protocol, then use traditional key-value way to get or put state onto the store, but literal keys might cause bugs due to typos, based on that, we decided to introduce key path into shared state extension.

## How we work on shared state extension with key path

Key path is a feature provided by Swift, which give us a safer way to work on variables because of static type.

To improve the experience about using shared state extension, this time we introduced key path to this extension to free developers from typo caused bugs.

There are two types to make it runs, one is `SharedStateKey`, another one is `SharedStateValues`.

`SharedStateKey` represents a type for you to define your custom keys, here is a case:

```swift
struct TimestampKey: SharedStateKey {

    // this will give compiler a hint about concrete type.
    static var currentValue: TimeInterval?
}
```

`SharedStateValues` is a struct acts as entry point for you to extend variables as many as you like, which will also generate key path for your custom values, below is a case:

```swift
extension SharedStateValues {

    // this will generate a key path for `timestamp` variable.
    var timestamp: TimeInterval? {
        get { Self[TimestampKey.self] }
        set { Self[TimestampKey.self] = newValue }
    }
}
```

Above are all you need to do before making your variables can be shared between different scenes.

After that, you can get or put your variables by as same as before, the only one difference is you pass key path to method as arguments.

```swift

scene.sbx.getSharedState(by: \.timestamp)
// or
scene.sbx.putSharedState(by: \.timestamp, sharedState: value)

```

We also know the power of property wrapper, especially we have seen tons of usage of them in SwiftUI, so here we bring a new property wrapper for key path driven shared state extension, just like how `@Environment` works in SwiftUI.

```swift
class ViewController: UIViewController, Scene {

    // ...
    @SharedStateInjected(\.timestamp)
    var timestamp: TimeInterval?
}
```

Hope this newer, safer way to share state between scenes can reduce risks and improve experience to a higher level.
