### PR TITLE
Simplify configuration initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Based on these two pain points, I conceived the framework to enable us to develo
 
 To integrate using Apple's SPM, add following as a dependency to your Target.
 
-`.package(url: "https://github.com/lumiasaki/SceneBox.git", .upToNextMajor(from: "0.3.1"))`
+`.package(url: "https://github.com/lumiasaki/SceneBox.git", .upToNextMajor(from: "0.4.0"))`
 
 ## How to use
 
@@ -24,14 +24,13 @@ struct SceneState: RawRepresentable, Hashable, Equatable {
     var rawValue: Int
 
     static let home = SceneState(rawValue: NavigationExtension.entry)
-    static let detail = SceneState(rawValue: 1)
-    static let termination = SceneState(rawValue: NavigationExtension.termination)
+    static let detail = SceneState(rawValue: 1)    
 }
 
 extension SceneState: CaseIterable {
 
     /// Help to register all states.
-    static var allCases: [SceneState] { [.home, .detail, .termination] }
+    static var allCases: [SceneState] { [.home, .detail] }
 }
 
 ```
@@ -40,14 +39,15 @@ extension SceneState: CaseIterable {
 
 ```swift
 
-let identifier = UUID()
-let sceneState = SceneState.home.rawValue
+let sceneStates = Set([
+    SceneState.home.rawValue
+])
 
-let sceneBoxConfiguration = Configuration(stateSceneIdentifierTable: [sceneState : identifier])
+let sceneBoxConfiguration = Configuration(sceneStates: sceneStates)
 
 ```
 
-I strongly recommend you to use helper `SceneStateConfiguration` in `Example Project` to simplify `Configuration` initialization.
+Or generate it by using `ConfigurationFile` way to put your setting steps into one place.
 
 ### Initiate SceneBox
 
@@ -63,7 +63,7 @@ let sceneBox = SceneBox(configuration: sceneBoxConfiguration) { scene, sceneBox 
 
 ```swift
 
-box.lazyAdd(identifier: sceneStateConfiguration.identifier(with: .home)) {
+box.lazyAdd(sceneState: SceneState.home.rawValue) {
                 let viewModel = HomeViewModel()
                 let viewController = HomeViewController(viewModel: viewModel)
                 viewModel.scene = viewController

--- a/Sources/SceneBox/Configuration.swift
+++ b/Sources/SceneBox/Configuration.swift
@@ -9,6 +9,16 @@
 import Foundation
 import UIKit
 
+/// A convenient way to configure your scene states at a place.
+public protocol ConfigurationFile {
+    
+    /// Distribute scene states for your scenes from product aspect.
+    static var sceneStates: Set<Int> { get }
+    
+    /// Enabled `Extension`s.
+    static var extensions: [Extension] { get }
+}
+
 /// Configuration of SceneBox, you must create a valid configuration before you initialize the SceneBox.
 public final class Configuration {
         
@@ -16,13 +26,41 @@ public final class Configuration {
     public let stateSceneIdentifierTable: [Int : UUID]
     
     /// Navigating between scenes driven by navigation controller, you need to assign a navigation controller for the SceneBox.
+    @available(*, deprecated, message: "No longer need to assign navigation controller to configuration, here will always be nil.")
     public var navigationController: UINavigationController?
     
     /// Extensions have been set to configuration.
     public private(set) lazy var extensions: [String : Extension] = Dictionary()
+    
+    /// A set of state for `Scene`s from product level.
+    /// - Parameter sceneStates: Scene states.
+    public init(sceneStates: Set<Int>) {
+        func generateStateSceneIdentifierTable(from sceneStates: Set<Int>) -> [Int : UUID] {
+            var table: [Int : UUID] = Dictionary()
+            
+            sceneStates.forEach { sceneState in
+                table[sceneState] = UUID()
+            }
+            
+            return table
+        }
         
+        self.stateSceneIdentifierTable = generateStateSceneIdentifierTable(from: sceneStates)
+    }
+    
+    /// Convenience initializer for `Configuration` with a configuration file.
+    /// - Parameter configurationFile: ConfigurationFile.
+    public convenience init(configurationFile: ConfigurationFile.Type) throws {
+        self.init(sceneStates: configurationFile.sceneStates)
+        
+        for ext in configurationFile.extensions {
+            try setExtension(ext)
+        }
+    }
+    
     /// Initializer for Configuration
     /// - Parameter stateSceneIdentifierTable: Table for state of scenes and the corresponding identifiers.
+    @available(*, deprecated, message: "Use init(sceneStates:) instead.")
     public init(stateSceneIdentifierTable: [Int : UUID]) {
         self.stateSceneIdentifierTable = stateSceneIdentifierTable
     }

--- a/Sources/SceneBox/Extension/Core/NavigationExtension.swift
+++ b/Sources/SceneBox/Extension/Core/NavigationExtension.swift
@@ -132,6 +132,15 @@ extension SceneCapabilityWrapper {
         ext.transit(to: state)
     }
     
+    /// Transit to termination state of scene, the scene box will be terminated soon after calling this.
+    public func terminate() {
+        guard let ext = try? _getExtension(by: NavigationExtension.self) else {
+            return
+        }
+        
+        ext.transit(to: NavigationExtension.termination)
+    }
+    
     /// Return true if the current scene is the active one. `Active` means the caller scene is on the scene as the latest scene in the stack.
     /// - Returns: The result of testing.
     public func currentIsActiveScene() -> Bool {

--- a/Sources/SceneBox/Extension/Core/SharedStateExtension.swift
+++ b/Sources/SceneBox/Extension/Core/SharedStateExtension.swift
@@ -120,7 +120,9 @@ public final class SharedStateExtension: Extension {
     
     private var stateValue: AnyObject?
     
-    init(stateValue: AnyObject?) {
+    /// Initiate `SharedStateExtension` with a state instance, `stateValue` must be reference type.
+    /// - Parameter stateValue: AnyObject.
+    public init(stateValue: AnyObject?) {
         self.stateValue = stateValue
     }
     

--- a/Tests/SceneBoxTests/Support/MyConfigurationFile.swift
+++ b/Tests/SceneBoxTests/Support/MyConfigurationFile.swift
@@ -1,0 +1,23 @@
+//
+//  MyConfigurationFile.swift
+//  SceneBox
+//
+//  Created by Lumia_Saki on 2021/7/29.
+//  Copyright © 2021年 tianren.zhu. All rights reserved.
+//
+
+import Foundation
+import SceneBox
+
+struct MyConfigurationFile: ConfigurationFile {
+    
+    static var sceneStates: Set<Int> = Set([
+        SceneState.page1.rawValue,
+        SceneState.page2.rawValue
+    ])
+    
+    static var extensions: [Extension] = [
+        NavigationExtension(),
+        SharedStateExtension(stateValue: MyState())
+    ]
+}

--- a/Tests/SceneBoxTests/Support/SceneState.swift
+++ b/Tests/SceneBoxTests/Support/SceneState.swift
@@ -1,0 +1,18 @@
+//
+//  SceneState.swift
+//  SceneBox
+//
+//  Created by Lumia_Saki on 2021/7/29.
+//  Copyright © 2021年 tianren.zhu. All rights reserved.
+//
+
+import Foundation
+import SceneBox
+
+struct SceneState: RawRepresentable, Hashable, Equatable {
+            
+    var rawValue: Int
+    
+    static let page1 = SceneState(rawValue: NavigationExtension.entry)
+    static let page2 = SceneState(rawValue: 1)    
+}


### PR DESCRIPTION
## Current situation

Currently, when developers initialize an instance of `Configuration` for `SceneBox`, they need to distribute not only states from product aspect, but also unique identifiers for them, which is meaningless for developers, we want developers keep focusing on states from product level, since that this time we simplify the while process for initialization of `SceneBox`  and `Configuration`.

## Changes

Based on conclusions as above, we deleted the process about distribution unique identifiers and bind them with state of scenes. Meanwhile, `lazyAdd` APIs from `SceneBox` switched to use `scene state` rather than `identifier`.

Further more, we believe the `navigationController` assignment in `Configuration` was also a redundant process, due to developers already set navigation controller for the first scene in `entry` block.

Lastly, in order to organize the setting steps of `SceneBox` into one place, this time we introduced a new type `ConfigurationFile`, which can make you to put all your configurations into one place, and be easier to reuse it just like a file, in this `ConfigurationFile`, you can distribute your scene states and decide which extensions will be enabled for `SceneBox`.